### PR TITLE
Separate files struct and methods to the other go file.

### DIFF
--- a/files.go
+++ b/files.go
@@ -1,0 +1,20 @@
+package main
+
+type File struct {
+	Name        string
+	CommitCount int
+}
+
+type Files []File
+
+func (f Files) Len() int {
+	return len(f)
+}
+
+func (f Files) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+func (f Files) Less(i, j int) bool {
+	return f[i].CommitCount > f[j].CommitCount
+}

--- a/main.go
+++ b/main.go
@@ -75,22 +75,3 @@ func getCommitTimes(filename string) int {
 	str = strings.Trim(str, "\n")
 	return len(strings.Split(str, "\n"))
 }
-
-type File struct {
-	Name        string
-	CommitCount int
-}
-
-type Files []File
-
-func (f Files) Len() int {
-	return len(f)
-}
-
-func (f Files) Swap(i, j int) {
-	f[i], f[j] = f[j], f[i]
-}
-
-func (f Files) Less(i, j int) bool {
-	return f[i].CommitCount > f[j].CommitCount
-}


### PR DESCRIPTION
### What

Separate `File` and `Files` structs and related methods to another go file.
### Why

This change just does nothing but it helps improving readability, I guess.
